### PR TITLE
Prompt with signer and hash for Micheline expressions

### DIFF
--- a/src/to_string.h
+++ b/src/to_string.h
@@ -10,10 +10,14 @@
 #include "cx.h"
 #include "ui.h"
 
+#define EXPR_HASH_SIZE 32
+#define EXPR_STRING_SIZE 56
+
 int pubkey_to_pkh_string(char *buff, uint32_t buff_size, cx_curve_t curve,
                          const cx_ecfp_public_key_t *public_key);
 int pkh_to_string(char *buff, uint32_t buff_size, cx_curve_t curve, const uint8_t hash[HASH_SIZE]);
 int parsed_contract_to_string(char *buff, uint32_t buff_size, const struct parsed_contract *contract);
+int expr_hash_to_string(char *buff, uint32_t buff_size, const uint8_t hash[EXPR_HASH_SIZE]);
 
 // These functions output terminating null bytes, and return the ending offset.
 #define MAX_INT_DIGITS 20

--- a/src/ui.h
+++ b/src/ui.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 
 #include "keys.h"
+#include "to_string.h"
 
 typedef bool (*callback_t)(void); // return true to go back to idle screen
 

--- a/src/ui_prompt.h
+++ b/src/ui_prompt.h
@@ -4,7 +4,8 @@
 
 #define MAX_SCREEN_COUNT 6 // Current maximum usage
 #define PROMPT_WIDTH 25
-#define VALUE_WIDTH PKH_STRING_SIZE
+// what are the implications of making this bigger?
+#define VALUE_WIDTH EXPR_STRING_SIZE
 
 // Displays labels (terminated with a NULL pointer) associated with data
 // If data is NULL, assume we've filled it in directly with get_value_buffer


### PR DESCRIPTION
This is my attempt at handling the 0x05 magic byte.

You can test this via e.g.:

```bash
tezos-client hash data 0x of type bytes # (note "Raw packed data", which is signed, and base58 "Hash")
tezos-client sign bytes 0x050a00000000 for sandbox_ed_0_0 # will give error if sig was bad
```

You might use `hash data` and `sign bytes 0x05` for a Michelson contract which does `PACK` and `CHECK_SIGNATURE` (like the multisigs). But really, the bytes here can be anything starting with 0x05, which only conventionally tags a packed Micheline expression.

<strike>Unfortunately, in order to show the expr hash for transfer/origination involving scripts, it seems we need to additionally parse Micheline expressions enough to determine their lengths.</strike> Edit: actually, the expressions do have length prefixes, whew!