### PR TITLE
Break "register-as-delegate" means "authorize-ledger-to-bake" in baking app

### DIFF
--- a/src/apdu_baking.c
+++ b/src/apdu_baking.c
@@ -85,13 +85,13 @@ unsigned int handle_apdu_main_hwm(__attribute__((unused)) uint8_t instruction) {
 
 
 unsigned int handle_apdu_query_auth_key(__attribute__((unused)) uint8_t instruction) {
-    uint8_t const length = N_data.bip32_path.length;
+    uint8_t const length = N_data.baking_key.bip32_path.length;
 
     uint32_t tx = 0;
     G_io_apdu_buffer[tx++] = length;
 
     for (uint8_t i = 0; i < length; ++i) {
-        tx = send_word_big_endian(tx, N_data.bip32_path.components[i]);
+        tx = send_word_big_endian(tx, N_data.baking_key.bip32_path.components[i]);
     }
 
     G_io_apdu_buffer[tx++] = 0x90;

--- a/src/apdu_pubkey.c
+++ b/src/apdu_pubkey.c
@@ -18,7 +18,7 @@ static bool pubkey_ok(void) {
 
 #ifdef BAKING_APP
 static bool baking_ok(void) {
-    authorize_baking(G.curve, &G.bip32_path);
+    authorize_baking(G.key.curve, &G.key.bip32_path);
     pubkey_ok();
     return true;
 }
@@ -33,22 +33,21 @@ unsigned int handle_apdu_get_public_key(uint8_t instruction) {
     if (instruction == INS_GET_PUBLIC_KEY) require_hid();
 
     uint8_t const curve_code = READ_UNALIGNED_BIG_ENDIAN(uint8_t, &G_io_apdu_buffer[OFFSET_CURVE]);
-    G.curve = curve_code_to_curve(curve_code);
+    G.key.curve = curve_code_to_curve(curve_code);
 
     size_t const cdata_size = READ_UNALIGNED_BIG_ENDIAN(uint8_t, &G_io_apdu_buffer[OFFSET_LC]);
 
 #ifdef BAKING_APP
     if (cdata_size == 0 && instruction == INS_AUTHORIZE_BAKING) {
-        G.curve = N_data.baking_key.curve;
-        copy_bip32_path(&G.bip32_path, &N_data.baking_key.bip32_path);
+        copy_bip32_path_with_curve(&G.key, &N_data.baking_key);
     } else {
 #endif
-        read_bip32_path(&G.bip32_path, dataBuffer, cdata_size);
+        read_bip32_path(&G.key.bip32_path, dataBuffer, cdata_size);
 #ifdef BAKING_APP
-        if (G.bip32_path.length == 0) THROW(EXC_WRONG_LENGTH_FOR_INS);
+        if (G.key.bip32_path.length == 0) THROW(EXC_WRONG_LENGTH_FOR_INS);
     }
 #endif
-    cx_ecfp_public_key_t const *const pubkey = generate_public_key(G.curve, &G.bip32_path);
+    cx_ecfp_public_key_t const *const pubkey = generate_public_key(G.key.curve, &G.key.bip32_path);
     memcpy(&G.public_key, pubkey, sizeof(G.public_key));
 
     if (instruction == INS_GET_PUBLIC_KEY) {
@@ -69,6 +68,6 @@ unsigned int handle_apdu_get_public_key(uint8_t instruction) {
 #ifdef BAKING_APP
         }
 #endif
-        prompt_address(bake, G.curve, &G.public_key, cb, delay_reject);
+        prompt_address(bake, G.key.curve, &G.public_key, cb, delay_reject);
     }
 }

--- a/src/apdu_pubkey.c
+++ b/src/apdu_pubkey.c
@@ -39,8 +39,8 @@ unsigned int handle_apdu_get_public_key(uint8_t instruction) {
 
 #ifdef BAKING_APP
     if (cdata_size == 0 && instruction == INS_AUTHORIZE_BAKING) {
-        G.curve = N_data.curve;
-        copy_bip32_path(&G.bip32_path, &N_data.bip32_path);
+        G.curve = N_data.baking_key.curve;
+        copy_bip32_path(&G.bip32_path, &N_data.baking_key.bip32_path);
     } else {
 #endif
         read_bip32_path(&G.bip32_path, dataBuffer, cdata_size);

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -36,8 +36,6 @@ static bool ok(void) {
     return true;
 }
 
-#define SET_STATIC_UI_VALUE(index, str) register_ui_callback(index, copy_string, STATIC_UI_VALUE(str))
-
 __attribute__((noreturn)) static void prompt_setup(
     ui_callback_t const ok_cb,
     ui_callback_t const cxl_cb)
@@ -57,7 +55,7 @@ __attribute__((noreturn)) static void prompt_setup(
         NULL,
     };
 
-    SET_STATIC_UI_VALUE(TYPE_INDEX, "Baking?");
+    REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Baking?");
     register_ui_callback(ADDRESS_INDEX, bip32_path_with_curve_to_pkh_string, &G.key);
     register_ui_callback(CHAIN_INDEX, chain_id_to_string_with_aliases, &G.main_chain_id);
     register_ui_callback(MAIN_HWM_INDEX, number_to_string_indirect32, &G.hwm.main);

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -23,8 +23,8 @@ struct setup_wire {
 
 static bool ok(void) {
     UPDATE_NVRAM(ram, {
-        ram->curve = G.curve;
-        copy_bip32_path(&ram->bip32_path, &G.bip32_path);
+        ram->baking_key.curve = G.curve;
+        copy_bip32_path(&ram->baking_key.bip32_path, &G.bip32_path);
         ram->main_chain_id = G.main_chain_id;
         ram->hwm.main.highest_level = G.hwm.main;
         ram->hwm.main.had_endorsement = false;

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -23,22 +23,17 @@ struct setup_wire {
 
 static bool ok(void) {
     UPDATE_NVRAM(ram, {
-        ram->baking_key.curve = G.curve;
-        copy_bip32_path(&ram->baking_key.bip32_path, &G.bip32_path);
+        copy_bip32_path_with_curve(&ram->baking_key, &G.key);
         ram->main_chain_id = G.main_chain_id;
         ram->hwm.main.highest_level = G.hwm.main;
         ram->hwm.main.had_endorsement = false;
         ram->hwm.test.highest_level = G.hwm.test;
         ram->hwm.test.had_endorsement = false;
     });
-    delayed_send(provide_pubkey(G_io_apdu_buffer, &G.public_key));
-    return true;
-}
 
-static void pubkey_to_string(char *const out, size_t const out_size, cx_ecfp_public_key_t const *const pubkey) {
-    check_null(out);
-    check_null(pubkey);
-    pubkey_to_pkh_string(out, out_size, G.curve, pubkey);
+    cx_ecfp_public_key_t const *const pubkey = generate_public_key(G.key.curve, &G.key.bip32_path);
+    delayed_send(provide_pubkey(G_io_apdu_buffer, pubkey));
+    return true;
 }
 
 #define SET_STATIC_UI_VALUE(index, str) register_ui_callback(index, copy_string, STATIC_UI_VALUE(str))
@@ -63,7 +58,7 @@ __attribute__((noreturn)) static void prompt_setup(
     };
 
     SET_STATIC_UI_VALUE(TYPE_INDEX, "Baking?");
-    register_ui_callback(ADDRESS_INDEX, pubkey_to_string, &G.public_key);
+    register_ui_callback(ADDRESS_INDEX, bip32_path_with_curve_to_pkh_string, &G.key);
     register_ui_callback(CHAIN_INDEX, chain_id_to_string_with_aliases, &G.main_chain_id);
     register_ui_callback(MAIN_HWM_INDEX, number_to_string_indirect32, &G.hwm.main);
     register_ui_callback(TEST_HWM_INDEX, number_to_string_indirect32, &G.hwm.test);
@@ -78,7 +73,7 @@ __attribute__((noreturn)) unsigned int handle_apdu_setup(__attribute__((unused))
     if (buff_size < sizeof(struct setup_wire)) THROW(EXC_WRONG_LENGTH_FOR_INS);
 
     uint8_t const curve_code = READ_UNALIGNED_BIG_ENDIAN(uint8_t, &G_io_apdu_buffer[OFFSET_CURVE]);
-    G.curve = curve_code_to_curve(curve_code);
+    G.key.curve = curve_code_to_curve(curve_code);
 
     {
         struct setup_wire const *const buff_as_setup = (struct setup_wire const *)&G_io_apdu_buffer[OFFSET_CDATA];
@@ -87,13 +82,10 @@ __attribute__((noreturn)) unsigned int handle_apdu_setup(__attribute__((unused))
         G.main_chain_id.v = CONSUME_UNALIGNED_BIG_ENDIAN(consumed, uint32_t, (uint8_t const *)&buff_as_setup->main_chain_id);
         G.hwm.main = CONSUME_UNALIGNED_BIG_ENDIAN(consumed, uint32_t, (uint8_t const *)&buff_as_setup->hwm.main);
         G.hwm.test = CONSUME_UNALIGNED_BIG_ENDIAN(consumed, uint32_t, (uint8_t const *)&buff_as_setup->hwm.test);
-        consumed += read_bip32_path(&G.bip32_path, (uint8_t const *)&buff_as_setup->bip32_path, buff_size - consumed);
+        consumed += read_bip32_path(&G.key.bip32_path, (uint8_t const *)&buff_as_setup->bip32_path, buff_size - consumed);
 
         if (consumed != buff_size) THROW(EXC_WRONG_LENGTH);
     }
-
-    cx_ecfp_public_key_t const *const pubkey = generate_public_key(G.curve, &G.bip32_path);
-    memcpy(&G.public_key, pubkey, sizeof(G.public_key));
 
     prompt_setup(ok, delay_reject);
 }

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -142,8 +142,6 @@ const char *const insecure_values[] = {
 
 #define MAX_NUMBER_CHARS (MAX_INT_DIGITS + 2) // include decimal point and terminating null
 
-#define SET_STATIC_UI_VALUE(index, str) register_ui_callback(index, copy_string, STATIC_UI_VALUE(str))
-
 // Return false if the transaction isn't easily parseable, otherwise prompt with given callbacks
 // and do not return, but rather throw ASYNC.
 static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve,
@@ -206,7 +204,7 @@ static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve
                 register_ui_callback(PERIOD_INDEX, number_to_string_indirect32, &ops->operation.proposal.voting_period);
                 register_ui_callback(PROTOCOL_HASH_INDEX, protocol_hash_to_string, ops->operation.proposal.protocol_hash);
 
-                SET_STATIC_UI_VALUE(TYPE_INDEX, "Proposal");
+                REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Proposal");
                 ui_prompt(proposal_prompts, NULL, ok, cxl);
             }
 
@@ -232,13 +230,13 @@ static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve
 
                 switch (ops->operation.ballot.vote) {
                     case BALLOT_VOTE_YEA:
-                        SET_STATIC_UI_VALUE(TYPE_INDEX, "Yea");
+                        REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Yea");
                         break;
                     case BALLOT_VOTE_NAY:
-                        SET_STATIC_UI_VALUE(TYPE_INDEX, "Nay");
+                        REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Nay");
                         break;
                     case BALLOT_VOTE_PASS:
-                        SET_STATIC_UI_VALUE(TYPE_INDEX, "Pass");
+                        REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Pass");
                         break;
                 }
 
@@ -295,7 +293,7 @@ static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve
 
                 if (!(ops->operation.flags & ORIGINATION_FLAG_SPENDABLE)) return false;
 
-                SET_STATIC_UI_VALUE(TYPE_INDEX, "Origination");
+                REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Origination");
                 register_ui_callback(AMOUNT_INDEX, microtez_to_string_indirect, &ops->operation.amount);
 
                 const char *const *prompts;
@@ -307,14 +305,14 @@ static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve
                                          &ops->operation.delegate);
                 } else if (delegatable && !has_delegate) {
                     prompts = origination_prompts_delegatable;
-                    SET_STATIC_UI_VALUE(DELEGATE_INDEX, "Any");
+                    REGISTER_STATIC_UI_VALUE(DELEGATE_INDEX, "Any");
                 } else if (!delegatable && has_delegate) {
                     prompts = origination_prompts_fixed;
                     register_ui_callback(DELEGATE_INDEX, parsed_contract_to_string,
                                          &ops->operation.delegate);
                 } else if (!delegatable && !has_delegate) {
                     prompts = origination_prompts_undelegatable;
-                    SET_STATIC_UI_VALUE(DELEGATE_INDEX, "Disabled");
+                    REGISTER_STATIC_UI_VALUE(DELEGATE_INDEX, "Disabled");
                 }
 
                 ui_prompt(prompts, NULL, ok, cxl);
@@ -352,7 +350,7 @@ static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve
                     NULL,
                 };
 
-                SET_STATIC_UI_VALUE(TYPE_INDEX, "Delegation");
+                REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Delegation");
 
                 bool withdrawal = ops->operation.destination.originated == 0 &&
                     ops->operation.destination.curve_code == TEZOS_NO_CURVE;
@@ -387,7 +385,7 @@ static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve
                                      &ops->total_storage_limit);
                 register_ui_callback(AMOUNT_INDEX, microtez_to_string_indirect, &ops->operation.amount);
 
-                SET_STATIC_UI_VALUE(TYPE_INDEX, "Transaction");
+                REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Transaction");
 
                 ui_prompt(transaction_prompts, NULL, ok, cxl);
             }
@@ -410,7 +408,7 @@ static bool prompt_transaction(const void *data, size_t length, cx_curve_t curve
                     NULL,
                 };
 
-                SET_STATIC_UI_VALUE(TYPE_INDEX, "To Blockchain");
+                REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "To Blockchain");
                 register_ui_callback(STORAGE_INDEX, number_to_string_indirect64,
                                      &ops->total_storage_limit);
                 register_ui_callback(SOURCE_INDEX, parsed_contract_to_string, &ops->operation.source);

--- a/src/baking_auth.c
+++ b/src/baking_auth.c
@@ -27,13 +27,13 @@ static void write_high_watermark(parsed_baking_data_t const *const in) {
     });
 }
 
-void authorize_baking(cx_curve_t curve, bip32_path_t const *const bip32_path) {
+void authorize_baking(cx_curve_t const curve, bip32_path_t const *const bip32_path) {
     check_null(bip32_path);
-    if (bip32_path->length > NUM_ELEMENTS(N_data.bip32_path.components) || bip32_path->length == 0) return;
+    if (bip32_path->length > NUM_ELEMENTS(N_data.baking_key.bip32_path.components) || bip32_path->length == 0) return;
 
     UPDATE_NVRAM(ram, {
-        ram->curve = curve;
-        copy_bip32_path(&ram->bip32_path, bip32_path);
+        ram->baking_key.curve = curve;
+        copy_bip32_path(&ram->baking_key.bip32_path, bip32_path);
     });
 }
 
@@ -51,9 +51,9 @@ static bool is_level_authorized(parsed_baking_data_t const *const baking_info) {
 bool is_path_authorized(cx_curve_t curve, bip32_path_t const *const bip32_path) {
     check_null(bip32_path);
     return
-        curve == N_data.curve &&
+        curve == N_data.baking_key.curve &&
         bip32_path->length > 0 &&
-        bip32_paths_eq(bip32_path, &N_data.bip32_path);
+        bip32_paths_eq(bip32_path, &N_data.baking_key.bip32_path);
 }
 
 void guard_baking_authorized(cx_curve_t curve, void *data, int datalen, bip32_path_t const *const bip32_path) {

--- a/src/baking_auth.h
+++ b/src/baking_auth.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void authorize_baking(cx_curve_t curve, bip32_path_t const *const bip32_path);
+void authorize_baking(cx_curve_t const curve, bip32_path_t const *const bip32_path);
 void guard_baking_authorized(cx_curve_t curve, void *data, int datalen, bip32_path_t const *const bip32_path);
 bool is_path_authorized(cx_curve_t curve, bip32_path_t const *const bip32_path);
 void update_high_water_mark(void *data, int datalen);

--- a/src/globals.c
+++ b/src/globals.c
@@ -41,13 +41,13 @@ high_watermark_t *select_hwm_by_chain(chain_id_t const chain_id, nvram_data *con
 void update_baking_idle_screens(void) {
     number_to_string(global.ui.baking_idle_screens.hwm, N_data.hwm.main.highest_level);
 
-    if (N_data.bip32_path.length == 0) {
+    if (N_data.baking_key.bip32_path.length == 0) {
         STRCPY(global.ui.baking_idle_screens.pkh, "No Key Authorized");
     } else {
-        cx_ecfp_public_key_t const *const pubkey = generate_public_key(N_data.curve, &N_data.bip32_path);
+        cx_ecfp_public_key_t const *const pubkey = generate_public_key(N_data.baking_key.curve, &N_data.baking_key.bip32_path);
         pubkey_to_pkh_string(
             global.ui.baking_idle_screens.pkh, sizeof(global.ui.baking_idle_screens.pkh),
-            N_data.curve, pubkey);
+            N_data.baking_key.curve, pubkey);
     }
 
     chain_id_to_string_with_aliases(global.ui.baking_idle_screens.chain, sizeof(global.ui.baking_idle_screens.chain), &N_data.main_chain_id);

--- a/src/globals.h
+++ b/src/globals.h
@@ -45,6 +45,10 @@ typedef struct {
       bool is_hash_state_inited;
       uint8_t magic_number;
       bool hash_only;
+
+      struct {
+          uint64_t total_fee;
+      } register_delegate;
     } sign;
 
     struct {

--- a/src/globals.h
+++ b/src/globals.h
@@ -32,9 +32,8 @@ typedef struct {
     } baking;
 
     struct {
+      bip32_path_with_curve_t key;
       cx_ecfp_public_key_t public_key;
-      bip32_path_t bip32_path;
-      cx_curve_t curve;
     } pubkey;
 
     struct {

--- a/src/globals.h
+++ b/src/globals.h
@@ -49,8 +49,7 @@ typedef struct {
     } pubkey;
 
     struct {
-      bip32_path_t bip32_path;
-      cx_curve_t curve;
+      bip32_path_with_curve_t key;
 
       uint8_t message_data[TEZOS_BUFSIZE];
       uint32_t message_data_length;

--- a/src/globals.h
+++ b/src/globals.h
@@ -49,9 +49,7 @@ typedef struct {
     } sign;
 
     struct {
-        bip32_path_t bip32_path;
-        cx_curve_t curve;
-        cx_ecfp_public_key_t public_key;
+        bip32_path_with_curve_t key;
         chain_id_t main_chain_id;
         struct {
             level_t main;

--- a/src/globals.h
+++ b/src/globals.h
@@ -22,17 +22,6 @@ struct priv_generate_key_pair {
     struct key_pair res;
 };
 
-struct apdu_setup_globals {
-    bip32_path_t bip32_path;
-    cx_curve_t curve;
-    cx_ecfp_public_key_t public_key;
-    chain_id_t main_chain_id;
-    struct {
-        level_t main;
-        level_t test;
-    } hwm;
-};
-
 typedef struct {
   void *stack_root;
   apdu_handler handlers[INS_MAX];
@@ -59,7 +48,16 @@ typedef struct {
       bool hash_only;
     } sign;
 
-    struct apdu_setup_globals setup;
+    struct {
+        bip32_path_t bip32_path;
+        cx_curve_t curve;
+        cx_ecfp_public_key_t public_key;
+        chain_id_t main_chain_id;
+        struct {
+            level_t main;
+            level_t test;
+        } hwm;
+    } setup;
   } u;
 
   struct {

--- a/src/to_string.c
+++ b/src/to_string.c
@@ -42,6 +42,15 @@ void pubkey_to_pkh_string(
     pkh_to_string(out, out_size, curve, hash);
 }
 
+void bip32_path_with_curve_to_pkh_string(char *const out, size_t const out_size, bip32_path_with_curve_t const *const key) {
+    check_null(out);
+    check_null(key);
+
+    cx_ecfp_public_key_t const *const pubkey = generate_public_key(key->curve, &key->bip32_path);
+    pubkey_to_pkh_string(out, out_size, key->curve, pubkey);
+}
+
+
 void compute_hash_checksum(uint8_t out[TEZOS_HASH_CHECKSUM_SIZE], void const *const data, size_t size) {
     uint8_t checksum[32];
     cx_hash_sha256(data, size, checksum, sizeof(checksum));

--- a/src/to_string.c
+++ b/src/to_string.c
@@ -28,11 +28,18 @@ void parsed_contract_to_string(char *buff, uint32_t buff_size, const struct pars
     pkh_to_string(buff, buff_size, curve, contract->hash);
 }
 
-void pubkey_to_pkh_string(char *buff, uint32_t buff_size, cx_curve_t curve,
-                          const cx_ecfp_public_key_t *public_key) {
+void pubkey_to_pkh_string(
+    char *const out,
+    size_t const out_size,
+    cx_curve_t const curve,
+    cx_ecfp_public_key_t const *const public_key
+) {
+    check_null(out);
+    check_null(public_key);
+
     uint8_t hash[HASH_SIZE];
     public_key_hash(hash, curve, public_key);
-    pkh_to_string(buff, buff_size, curve, hash);
+    pkh_to_string(out, out_size, curve, hash);
 }
 
 void compute_hash_checksum(uint8_t out[TEZOS_HASH_CHECKSUM_SIZE], void const *const data, size_t size) {

--- a/src/to_string.h
+++ b/src/to_string.h
@@ -15,6 +15,11 @@ void pubkey_to_pkh_string(
     cx_curve_t const curve,
     cx_ecfp_public_key_t const *const public_key
 );
+void bip32_path_with_curve_to_pkh_string(
+    char *const out,
+    size_t const out_size,
+    bip32_path_with_curve_t const *const key
+;
 void protocol_hash_to_string(char *buff, const size_t buff_size, const uint8_t hash[PROTOCOL_HASH_SIZE]);
 void parsed_contract_to_string(char *buff, uint32_t buff_size, const struct parsed_contract *contract);
 void chain_id_to_string(char *buff, size_t const buff_size, chain_id_t const chain_id);

--- a/src/to_string.h
+++ b/src/to_string.h
@@ -9,8 +9,12 @@
 #include "types.h"
 #include "ui.h"
 
-void pubkey_to_pkh_string(char *buff, uint32_t buff_size, cx_curve_t curve,
-                          const cx_ecfp_public_key_t *public_key);
+void pubkey_to_pkh_string(
+    char *const out,
+    size_t const out_size,
+    cx_curve_t const curve,
+    cx_ecfp_public_key_t const *const public_key
+);
 void protocol_hash_to_string(char *buff, const size_t buff_size, const uint8_t hash[PROTOCOL_HASH_SIZE]);
 void parsed_contract_to_string(char *buff, uint32_t buff_size, const struct parsed_contract *contract);
 void chain_id_to_string(char *buff, size_t const buff_size, chain_id_t const chain_id);

--- a/src/types.h
+++ b/src/types.h
@@ -58,6 +58,11 @@ static inline bool bip32_paths_eq(bip32_path_t const *const a, bip32_path_t cons
 }
 
 typedef struct {
+    bip32_path_t bip32_path;
+    cx_curve_t curve;
+} bip32_path_with_curve_t;
+
+typedef struct {
     level_t highest_level;
     bool had_endorsement;
 } high_watermark_t;
@@ -68,8 +73,7 @@ typedef struct {
         high_watermark_t main;
         high_watermark_t test;
     } hwm;
-    cx_curve_t curve;
-    bip32_path_t bip32_path;
+    bip32_path_with_curve_t baking_key;
 } nvram_data;
 
 

--- a/src/types.h
+++ b/src/types.h
@@ -99,7 +99,7 @@ typedef struct {
 #define HASH_SIZE 20
 
 struct parsed_contract {
-    uint8_t originated;
+    uint8_t originated; // a lightweight bool
     uint8_t curve_code; // TEZOS_NO_CURVE in originated case
                         // An implicit contract with TEZOS_NO_CURVE means not present
     uint8_t hash[HASH_SIZE];

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "exception.h"
 #include "os.h"
 #include "os_io_seproxyhal.h"
 
@@ -44,23 +45,43 @@ typedef struct {
 } bip32_path_t;
 
 static inline void copy_bip32_path(bip32_path_t *const out, bip32_path_t const *const in) {
+    check_null(out);
+    check_null(in);
     memcpy(out->components, in->components, in->length * sizeof(*in->components));
     out->length = in->length;
 }
 
 static inline bool bip32_paths_eq(bip32_path_t const *const a, bip32_path_t const *const b) {
     return a == b || (
-            a != NULL &&
-            b != NULL &&
-            a->length == b->length &&
-            memcmp(a->components, b->components, a->length * sizeof(*a->components)) == 0
-        );
+        a != NULL &&
+        b != NULL &&
+        a->length == b->length &&
+        memcmp(a->components, b->components, a->length * sizeof(*a->components)) == 0
+    );
 }
+
 
 typedef struct {
     bip32_path_t bip32_path;
     cx_curve_t curve;
 } bip32_path_with_curve_t;
+
+static inline void copy_bip32_path_with_curve(bip32_path_with_curve_t *const out, bip32_path_with_curve_t const *const in) {
+    check_null(out);
+    check_null(in);
+    copy_bip32_path(&out->bip32_path, &in->bip32_path);
+    out->curve = in->curve;
+}
+
+static inline bool bip32_path_with_curve_eq(bip32_path_with_curve_t const *const a, bip32_path_with_curve_t const *const b) {
+    return a == b || (
+        a != NULL &&
+        b != NULL &&
+        bip32_paths_eq(&a->bip32_path, &b->bip32_path) &&
+        a->curve == b->curve
+    );
+}
+
 
 typedef struct {
     level_t highest_level;

--- a/src/ui_prompt.h
+++ b/src/ui_prompt.h
@@ -18,3 +18,4 @@ void clear_ui_callbacks(void);
 
 // This function registers how a value is to be produced
 void register_ui_callback(uint32_t which, string_generation_callback cb, const void *data);
+#define REGISTER_STATIC_UI_VALUE(index, str) register_ui_callback(index, copy_string, STATIC_UI_VALUE(str))


### PR DESCRIPTION
This is a backwards incompatible change. The baking app will now sign register-as-delegate (self delegation) operations only if it is *already* authorized to to bake for the delegate address. The prompt will show the fee instead of automatically rejecting fees that are too large.