### PR TITLE
Remove syntax error in src/types.h

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -167,7 +167,7 @@ typedef struct {
 })
 
 #define STATIC_UI_VALUE(str) ({ \
-    _Static_assert(sizeof(str) <= VALUE_WIDTH + 1/*null byte*/, str " won't fit in the UI.".); \
+    _Static_assert(sizeof(str) <= VALUE_WIDTH + 1/*null byte*/, str " won't fit in the UI."); \
     str; \
 })
 


### PR DESCRIPTION
This looks like an error, unsure why it doesn't result in a compiler error in the current setup.