### PR TITLE
Move flextesa-dev thunk out of tbp

### DIFF
--- a/nix/dep/flextesa-dev/default.nix
+++ b/nix/dep/flextesa-dev/default.nix
@@ -1,0 +1,4 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetchGit = {url, rev, ref ? null, branch ? null, sha256 ? null, fetchSubmodules ? null}:
+  assert !fetchSubmodules; (import <nixpkgs> {}).fetchgit { inherit url rev sha256; };
+in import (fetchGit (builtins.fromJSON (builtins.readFile ./git.json)))

--- a/nix/dep/flextesa-dev/git.json
+++ b/nix/dep/flextesa-dev/git.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://gitlab.com/obsidian.systems/tezos.git",
+  "rev": "08c288ebe13d3647294a8603358ad98771eea7b1",
+  "sha256": "0kdnzd3ib93r63h509jd5c85svj0wyqcyi1v85xkghg94raswj0b",
+  "fetchSubmodules": false,
+  "branch": "flextesa-dev-master"
+}

--- a/test/flextesa-dev.nix
+++ b/test/flextesa-dev.nix
@@ -1,0 +1,9 @@
+{}:
+
+with import ../nix/dep/tezos-baking-platform {};
+
+tezos.mkWithSrc {
+  net = /master;
+  src = ../nix/dep/flextesa-dev;
+  sha256 = "1kcsqp6wh1ipddychkdjsh3iw6xnkvymasbysxxhpr2yh5lis9jn";
+}

--- a/test/run-flextesa-tests.sh
+++ b/test/run-flextesa-tests.sh
@@ -14,7 +14,8 @@ fail() { "${___fail:?$1}"; }
 
 root="$(git rev-parse --show-toplevel)"
 
-tezos="${root}/nix/dep/tezos-baking-platform"
+tezos_baking_platform="${root}/nix/dep/tezos-baking-platform"
+flextesa_dev="${root}/test/flextesa-dev.nix"
 
 sandbox_args=""
 case "$protocol" in
@@ -27,8 +28,8 @@ case "$protocol" in
     ;;
 esac
 
-: "${client_bin_root:="$(nix-build "$tezos" -A tezos.$branch.kit --no-out-link)/bin"}"
-: "${test_bin_root:="$(nix-build "$tezos" -A tezos.flextesa-dev.kit --no-out-link)/bin"}"
+: "${client_bin_root:="$(nix-build "$tezos_baking_platform" -A tezos.$branch.kit --no-out-link)/bin"}"
+: "${test_bin_root:="$(nix-build "$flextesa_dev" -A kit --no-out-link)/bin"}"
 
 echo
 if [ "${ledger:-}" = "" ]; then


### PR DESCRIPTION
This is much easier to manage locally as we are frequently making
changes to the flextesa-dev branch. Now we don’t have to go through
tbp to make updates to flextesa-dev branch.