### PR TITLE
Code fixes from audit

### DIFF
--- a/src/apdu_baking.c
+++ b/src/apdu_baking.c
@@ -19,7 +19,7 @@ static bool reset_ok(void);
 size_t handle_apdu_reset(__attribute__((unused)) uint8_t instruction) {
     uint8_t *dataBuffer = G_io_apdu_buffer + OFFSET_CDATA;
     uint32_t dataLength = G_io_apdu_buffer[OFFSET_LC];
-    if (dataLength != sizeof(int)) {
+    if (dataLength != sizeof(level_t)) {
         THROW(EXC_WRONG_LENGTH_FOR_INS);
     }
     level_t const lvl = READ_UNALIGNED_BIG_ENDIAN(level_t, dataBuffer);

--- a/src/base58.c
+++ b/src/base58.c
@@ -31,7 +31,7 @@ bool b58enc(/* out */ char *b58, /* in/out */ size_t *b58sz, const void *data, s
 
     for (i = zcount, high = size - 1; i < binsz; ++i, high = j)
     {
-        for (carry = bin[i], j = size - 1; (j > high) || carry; --j)
+        for (carry = bin[i], j = size - 1; ((int)j >= 0) && ((j > high) || carry); --j)
         {
             carry += 256 * buf[j];
             buf[j] = carry % 58;

--- a/src/keys.h
+++ b/src/keys.h
@@ -35,7 +35,7 @@ static inline void generate_key_pair(
     check_null(out);
     key_pair_t *const result = generate_key_pair_return_global(derivation_type, bip32_path);
     memcpy(out, result, sizeof(*out));
-    memset(result, 0, sizeof(*result));
+    explicit_bzero(result, sizeof(*result));
 }
 
 // Non-reentrant


### PR DESCRIPTION
Assortment of changes based on audit:

- Use sizeof(level_t) instead of sizeof(int) in apdu_reset
- Use explicit_bzero in place of memset
- Guard against buffer underflow in b58enc

