### PR TITLE
Fix src/delegates.h generation in nix-build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,11 +44,15 @@ let
       app = bakingApp: pkgs.stdenv.mkDerivation {
         name = "ledger-app-tezos-nano-${bolos.name}-${if bakingApp then "baking" else "wallet"}";
         inherit src;
+        prePatch = ''
+          patchShebangs tools/gen-delegates.sh
+        '';
         postConfigure = ''
           PATH="$BOLOS_ENV/clang-arm-fropi/bin:$PATH"
         '';
         nativeBuildInputs = [
           (pkgs.python3.withPackages (ps: [ps.pillow ps.ledgerblue]))
+          pkgs.jq
         ];
         TARGET = bolos.target;
         GIT_DESCRIBE = gitDescribe;

--- a/tools/gen-delegates.sh
+++ b/tools/gen-delegates.sh
@@ -1,7 +1,6 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash -p jq
+#! /usr/bin/env sh
 
-root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 registry_json=$root/tools/BakersRegistryCoreUnfilteredData.json
 if [ $# -eq 1 ]; then


### PR DESCRIPTION
Originally this was broken because we can’t run nix-shell within a
nix-build. As a result some CI was broken.

This fixes the problem by removing the nix-shell stuff and just using
a normal bash script, providing jq via mkDerivation.
